### PR TITLE
Create foreign keys in CreateModel and AddField

### DIFF
--- a/tests/operations/test_add_field.py
+++ b/tests/operations/test_add_field.py
@@ -1,0 +1,126 @@
+"""
+Tests for AddField operation.
+"""
+
+from tortoise import fields
+from tortoise_pathway.operations import AddField
+from tortoise_pathway.state import State
+
+
+class TestSqliteDialect:
+    """Tests for AddField operation with SQLite dialect."""
+
+    def test_add_regular_field(self):
+        """Test SQL generation for adding a regular field."""
+        state = State("test")
+        state.schema["models"]["TestModel"] = {
+            "table": "test_table",
+            "app": "tests",
+        }
+
+        # Test adding a text field
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.TextField(null=True),
+            field_name="description",
+        )
+
+        sql = operation.forward_sql(state=state, dialect="sqlite")
+
+        assert sql == "ALTER TABLE test_table ADD COLUMN description TEXT"
+
+        # Test adding a non-nullable field with default
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.IntField(default=0),
+            field_name="count",
+        )
+
+        sql = operation.forward_sql(state=state, dialect="sqlite")
+
+        assert sql == "ALTER TABLE test_table ADD COLUMN count INT NOT NULL DEFAULT 0"
+
+    def test_add_foreign_key(self):
+        """Test SQL generation for adding a foreign key field with SQLite."""
+        state = State("test")
+
+        # Set up models in the state
+        state.schema["models"]["TestModel"] = {
+            "table": "test_table",
+            "app": "tests",
+        }
+
+        state.schema["models"]["User"] = {
+            "table": "users",
+            "app": "tests",
+        }
+
+        # Test adding a foreign key field
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.ForeignKeyField("tests.User", related_name="test_models"),
+            field_name="user",
+        )
+
+        sql = operation.forward_sql(state=state, dialect="sqlite")
+
+        assert sql == "ALTER TABLE test_table ADD COLUMN user_id INT NOT NULL REFERENCES users(id)"
+
+        # Test backward operation
+        backward_sql = operation.backward_sql(state=state)
+        assert "DROP COLUMN user_id" in backward_sql
+
+
+class TestPostgresDialect:
+    """Tests for AddField operation with PostgreSQL dialect."""
+
+    def test_add_regular_field(self):
+        """Test SQL generation for adding a regular field."""
+        state = State("test")
+        state.schema["models"]["TestModel"] = {
+            "table": "test_table",
+            "app": "tests",
+        }
+
+        # Test adding a text field
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.TextField(null=True),
+            field_name="description",
+        )
+
+        sql = operation.forward_sql(state=state, dialect="postgres")
+
+        assert sql == "ALTER TABLE test_table ADD COLUMN description TEXT"
+
+    def test_add_foreign_key(self):
+        """Test SQL generation for adding a foreign key field with PostgreSQL."""
+        state = State("test")
+
+        # Set up models in the state
+        state.schema["models"]["TestModel"] = {
+            "table": "test_table",
+            "app": "tests",
+        }
+
+        state.schema["models"]["Category"] = {
+            "table": "categories",
+            "app": "tests",
+        }
+
+        # Test adding a foreign key field
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.ForeignKeyField("tests.Category", related_name="test_models"),
+            field_name="category",
+        )
+
+        sql = operation.forward_sql(state=state, dialect="postgres")
+
+        expected_sql = (
+            "ALTER TABLE test_table ADD COLUMN category_id INT NOT NULL,\n"
+            "ADD CONSTRAINT fk_test_table_category_id "
+            "FOREIGN KEY (category_id) REFERENCES categories(id)"
+        )
+
+        assert sql == expected_sql

--- a/tests/operations/test_create_table.py
+++ b/tests/operations/test_create_table.py
@@ -38,3 +38,134 @@ async def test_create_table(setup_test_db):
 
     backward_sql = operation.backward_sql(state=state)
     assert "DROP TABLE test_create" in backward_sql
+
+
+class TestSqliteDialect:
+    def test_forward_sql_basic_fields(self):
+        """Test SQL generation for basic field types."""
+        state = State("test")
+
+        fields_dict = {
+            "id": fields.IntField(primary_key=True),
+            "name": fields.CharField(max_length=100),
+            "description": fields.TextField(null=True),
+            "is_active": fields.BooleanField(default=True),
+            "created_at": fields.DatetimeField(auto_now_add=True),
+            "score": fields.FloatField(null=True),
+        }
+
+        operation = CreateModel(
+            model="tests.models.TestModel",
+            fields=fields_dict,
+        )
+        operation.set_table_name("test_table")
+
+        # Test SQLite dialect
+        sql = operation.forward_sql(state=state, dialect="sqlite")
+
+        assert (
+            sql
+            == """CREATE TABLE "test_table" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    is_active INT NOT NULL DEFAULT 1,
+    created_at TIMESTAMP NOT NULL,
+    score REAL
+);"""
+        )
+
+    def test_forward_sql_field_constraints(self):
+        """Test SQL generation with various field constraints."""
+        state = State("test")
+
+        fields_dict = {
+            "id": fields.IntField(primary_key=True),
+            "username": fields.CharField(max_length=50, unique=True),
+            "email": fields.CharField(max_length=100, null=True, unique=True),
+            "age": fields.IntField(default=18),
+            "bio": fields.TextField(default="New user"),
+        }
+
+        operation = CreateModel(
+            model="tests.models.TestModel",
+            fields=fields_dict,
+        )
+        operation.set_table_name("test_constraints")
+
+        sql = operation.forward_sql(state=state)
+
+        assert (
+            sql
+            == """CREATE TABLE "test_constraints" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    email VARCHAR(100) UNIQUE,
+    age INT NOT NULL DEFAULT 18,
+    bio TEXT NOT NULL DEFAULT 'New user'
+);"""
+        )
+
+    def test_forward_sql_foreign_key(self):
+        """Test SQL generation with foreign key fields."""
+        state = State("test")
+
+        # First define the related model in the state
+        state.schema["models"]["User"] = {
+            "table": "users",
+            "app": "tests",
+        }
+
+        # Create model with a foreign key
+        fields_dict = {
+            "id": fields.IntField(primary_key=True),
+            "title": fields.CharField(max_length=100),
+            "user": fields.ForeignKeyField("tests.User", related_name="posts"),
+        }
+
+        operation = CreateModel(
+            model="tests.models.Post",
+            fields=fields_dict,
+        )
+        operation.set_table_name("posts")
+
+        sql = operation.forward_sql(state=state)
+
+        assert (
+            sql
+            == """CREATE TABLE "posts" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title VARCHAR(100) NOT NULL,
+    user_id INT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES "users" (id)
+);"""
+        )
+
+
+class TestPostgresDialect:
+    def test_forward_sql(self):
+        """Test SQL generation with PostgreSQL dialect."""
+        state = State("test")
+
+        fields_dict = {
+            "id": fields.IntField(primary_key=True),
+            "name": fields.CharField(max_length=100),
+            "data": fields.JSONField(),
+        }
+
+        operation = CreateModel(
+            model="tests.models.TestModel",
+            fields=fields_dict,
+        )
+        operation.set_table_name("test_postgres")
+
+        sql = operation.forward_sql(state=state, dialect="postgres")
+
+        assert (
+            sql
+            == """CREATE TABLE "test_postgres" (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    data JSONB NOT NULL
+);"""
+        )

--- a/tests/test_schema_diff_models.py
+++ b/tests/test_schema_diff_models.py
@@ -1,0 +1,318 @@
+"""
+Tests for the SchemaDiffer's ability to detect model changes.
+"""
+
+from typing import Dict, Any, cast
+from tortoise.fields import (
+    IntField,
+    CharField,
+    DatetimeField,
+)
+from tortoise.fields.relational import ForeignKeyFieldInstance
+
+from tortoise_pathway.state import State
+from tortoise_pathway.schema_differ import SchemaDiffer
+from tortoise_pathway.operations import CreateModel
+
+
+async def test_detect_basic_model_creation():
+    """Test detecting a single model creation with no relations."""
+    # Initialize state with no models
+    state = State("test")
+
+    # Create a SchemaDiffer with our state
+    differ = SchemaDiffer("test", state)
+
+    # Mock the get_model_schema method to return a schema with a new model
+    def mock_get_model_schema():
+        return {
+            "models": {
+                "TestModel": {
+                    "table": "test_model",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                        "created_at": DatetimeField(auto_now_add=True),
+                    },
+                    "indexes": [],
+                }
+            }
+        }
+
+    # Replace the method with our mock
+    differ.get_model_schema = mock_get_model_schema
+
+    # Detect changes
+    changes = await differ.detect_changes()
+
+    # There should be one change: CreateModel
+    assert len(changes) == 1
+    assert isinstance(changes[0], CreateModel)
+    assert changes[0].model == "test.TestModel"
+
+    # Access fields on the CreateModel operation
+    create_model_op = cast(CreateModel, changes[0])
+    assert len(create_model_op.fields) == 3
+    assert isinstance(create_model_op.fields["id"], IntField)
+    assert isinstance(create_model_op.fields["name"], CharField)
+    assert isinstance(create_model_op.fields["created_at"], DatetimeField)
+
+
+async def test_detect_single_relation_model_creation():
+    """Test detecting model creation with a single foreign key relation."""
+    # Initialize state with no models
+    state = State("test")
+
+    # Create a SchemaDiffer with our state
+    differ = SchemaDiffer("test", state)
+
+    # Mock the get_model_schema method to return a schema with related models
+    def mock_get_model_schema():
+        # Define the parent model fields
+        user_fields: Dict[str, Any] = {
+            "id": IntField(primary_key=True),
+            "name": CharField(max_length=100),
+        }
+
+        # Define the child model fields with a foreign key
+        post_fields: Dict[str, Any] = {
+            "id": IntField(primary_key=True),
+            "title": CharField(max_length=100),
+            "content": CharField(max_length=1000),
+            "user": ForeignKeyFieldInstance("test.User", related_name="posts", to_field="id"),
+        }
+
+        return {
+            "models": {
+                "User": {
+                    "table": "user",
+                    "fields": user_fields,
+                    "indexes": [],
+                },
+                "Post": {
+                    "table": "post",
+                    "fields": post_fields,
+                    "indexes": [],
+                },
+            }
+        }
+
+    # Replace the method with our mock
+    differ.get_model_schema = mock_get_model_schema
+
+    # Detect changes
+    changes = await differ.detect_changes()
+
+    # There should be two changes: CreateModel for User and Post
+    assert len(changes) == 2
+
+    # First change should be creating the User model (referenced model should be created first)
+    assert isinstance(changes[0], CreateModel)
+    assert changes[0].model == "test.User"
+
+    user_model = cast(CreateModel, changes[0])
+    assert len(user_model.fields) == 2  # id, name
+
+    # Second change should be creating the Post model
+    assert isinstance(changes[1], CreateModel)
+    assert changes[1].model == "test.Post"
+
+    post_model = cast(CreateModel, changes[1])
+    assert len(post_model.fields) == 4  # id, title, content, and user FK
+    assert isinstance(post_model.fields["user"], ForeignKeyFieldInstance)
+
+
+async def test_detect_multiple_relations_model_creation():
+    """Test detecting model creation with multiple foreign key relations between models."""
+    # Initialize state with no models
+    state = State("test")
+
+    # Create a SchemaDiffer with our state
+    differ = SchemaDiffer("test", state)
+
+    # Mock the get_model_schema method to return a schema with multiple related models
+    def mock_get_model_schema():
+        return {
+            "models": {
+                "Post": {
+                    "table": "post",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "title": CharField(max_length=100),
+                        "content": CharField(max_length=1000),
+                        "user": ForeignKeyFieldInstance(
+                            "test.User", related_name="posts", to_field="id"
+                        ),
+                    },
+                    "indexes": [],
+                },
+                "User": {
+                    "table": "user",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                    },
+                    "indexes": [],
+                },
+                "Comment": {
+                    "table": "comment",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "text": CharField(max_length=500),
+                        "user": ForeignKeyFieldInstance(
+                            "test.User", related_name="comments", to_field="id"
+                        ),
+                        "post": ForeignKeyFieldInstance(
+                            "test.Post", related_name="comments", to_field="id"
+                        ),
+                    },
+                    "indexes": [],
+                },
+            }
+        }
+
+    # Replace the method with our mock
+    differ.get_model_schema = mock_get_model_schema
+
+    # Detect changes
+    changes = await differ.detect_changes()
+
+    # There should be three changes: CreateModel for User, Post, and Comment
+    assert len(changes) == 3
+
+    # Changes should come in the correct order to respect dependencies
+    # First User, then Post, then Comment
+    model_names = [change.model.split(".")[-1] for change in changes]
+    assert model_names == ["User", "Post", "Comment"]
+
+    # Check that the Comment model has both ForeignKey fields
+    comment_model = cast(CreateModel, [m for m in changes if m.model == "test.Comment"][0])
+    assert isinstance(comment_model.fields["user"], ForeignKeyFieldInstance)
+    assert isinstance(comment_model.fields["post"], ForeignKeyFieldInstance)
+
+
+async def test_detect_circular_reference_model_creation():
+    """Test detecting model creation with circular references between models."""
+    # Initialize state with no models
+    state = State("test")
+
+    # Create a SchemaDiffer with our state
+    differ = SchemaDiffer("test", state)
+
+    # Mock the get_model_schema method to return a schema with circular references
+    def mock_get_model_schema():
+        return {
+            "models": {
+                "Course": {
+                    "table": "course",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                        "teacher": ForeignKeyFieldInstance(
+                            "test.Teacher", related_name="courses", to_field="id"
+                        ),
+                    },
+                    "indexes": [],
+                },
+                "Teacher": {
+                    "table": "teacher",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                        "department": ForeignKeyFieldInstance(
+                            "test.Department", related_name="teachers", to_field="id"
+                        ),
+                    },
+                    "indexes": [],
+                },
+                "Department": {
+                    "table": "department",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                        "school": ForeignKeyFieldInstance(
+                            "test.School", related_name="departments", to_field="id"
+                        ),
+                    },
+                    "indexes": [],
+                },
+                "School": {
+                    "table": "school",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                        "admin": ForeignKeyFieldInstance(
+                            "test.Admin", related_name="schools", to_field="id"
+                        ),
+                    },
+                    "indexes": [],
+                },
+                "Admin": {
+                    "table": "admin",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                    },
+                    "indexes": [],
+                },
+                "Student": {
+                    "table": "student",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "name": CharField(max_length=100),
+                    },
+                    "indexes": [],
+                },
+                "StudentCourse": {
+                    "table": "student_course",
+                    "fields": {
+                        "id": IntField(primary_key=True),
+                        "student": ForeignKeyFieldInstance(
+                            "test.Student", related_name="courses", to_field="id"
+                        ),
+                        "course": ForeignKeyFieldInstance(
+                            "test.Course", related_name="students", to_field="id"
+                        ),
+                        "grade": CharField(max_length=2, null=True),
+                    },
+                    "indexes": [],
+                },
+            }
+        }
+
+    # Replace the method with our mock
+    differ.get_model_schema = mock_get_model_schema
+
+    # Detect changes
+    changes = await differ.detect_changes()
+
+    # There should be 7 changes: CreateModel for all the models
+    assert len(changes) == 7
+
+    # Extract model names in order of creation
+    model_names = [change.model.split(".")[-1] for change in changes]
+
+    # Verify models with dependencies are created after the models they depend on
+    # For example, Teacher depends on Department, so Department must come before Teacher
+    def assert_model_created_before(dependent: str, dependency: str):
+        assert model_names.index(dependent) > model_names.index(dependency), (
+            f"{dependent} should be created after {dependency}"
+        )
+
+    # Admin should be created before School
+    assert_model_created_before("School", "Admin")
+
+    # School should be created before Department
+    assert_model_created_before("Department", "School")
+
+    # Department should be created before Teacher
+    assert_model_created_before("Teacher", "Department")
+
+    # Teacher should be created before Course
+    assert_model_created_before("Course", "Teacher")
+
+    # Student should be created before StudentCourse
+    assert_model_created_before("StudentCourse", "Student")
+
+    # Course should be created before StudentCourse
+    assert_model_created_before("StudentCourse", "Course")

--- a/tortoise_pathway/schema_differ.py
+++ b/tortoise_pathway/schema_differ.py
@@ -175,6 +175,7 @@ class SchemaDiffer:
         )
 
         # Tables to create (in models but not in current schema)
+        retries = 0
         while len(models_to_create) > 0:
             model_name = models_to_create.pop(0)
             model_info = model_schema["models"][model_name]
@@ -197,6 +198,9 @@ class SchemaDiffer:
                         break
 
             if try_again:
+                retries += 1
+                if retries > 50:
+                    raise ValueError(f"Possible circular dependency to {models_to_create}")
                 continue
 
             model_ref = f"{self.app_name}.{model_name}"

--- a/tortoise_pathway/schema_differ.py
+++ b/tortoise_pathway/schema_differ.py
@@ -164,19 +164,10 @@ class SchemaDiffer:
         model_schema = self.get_model_schema()
         changes = []
 
-        # Create a map of table names to their model for easy lookup
-        current_tables = {}
-        model_tables = {}
-
-        for model_name, model_info in current_schema["models"].items():
-            current_tables[model_info["table"]] = model_name
-
-        for model_name, model_info in model_schema["models"].items():
-            model_tables[model_info["table"]] = model_name
-
         # Tables to create (in models but not in current schema)
-        for table_name in sorted(set(model_tables.keys()) - set(current_tables.keys())):
-            model_name = model_tables[table_name]
+        for model_name in sorted(
+            set(model_schema["models"].keys()) - set(current_schema["models"].keys())
+        ):
             # Get the model info and extract field objects
             model_info = model_schema["models"][model_name]
             field_objects = model_info["fields"]  # Field objects are already stored directly
@@ -189,8 +180,9 @@ class SchemaDiffer:
             changes.append(operation)
 
         # Tables to drop (in current schema but not in models)
-        for table_name in sorted(set(current_tables.keys()) - set(model_tables.keys())):
-            model_name = current_tables[table_name]
+        for model_name in sorted(
+            set(current_schema["models"].keys()) - set(model_schema["models"].keys())
+        ):
             model_ref = f"{self.app_name}.{model_name}"
             changes.append(
                 DropModel(
@@ -199,13 +191,12 @@ class SchemaDiffer:
             )
 
         # For tables that exist in both
-        for table_name in sorted(set(current_tables.keys()) & set(model_tables.keys())):
-            current_model_name = current_tables[table_name]
-            model_model_name = model_tables[table_name]
-
+        for model_name in sorted(
+            set(current_schema["models"].keys()) & set(model_schema["models"].keys())
+        ):
             # Get the model info for both
-            current_model = current_schema["models"][current_model_name]
-            model_model = model_schema["models"][model_model_name]
+            current_model = current_schema["models"][model_name]
+            model_model = model_schema["models"][model_name]
 
             # Get field sets for comparison
             current_fields = current_model["fields"]
@@ -216,7 +207,7 @@ class SchemaDiffer:
             model_field_names = set(model_fields.keys())
 
             # Reference to the model
-            model_ref = f"{self.app_name}.{model_model_name}"
+            model_ref = f"{self.app_name}.{model_name}"
 
             # Fields to add (in model but not in current schema)
             for field_name in sorted(model_field_names - current_field_names):


### PR DESCRIPTION
- Create foreign keys in `CreateModel` and `AddField`
- Update `SchemaDiffer` to add `CreateModel` operations in topological order, so the referred models are created before referring models

This should fix https://github.com/henadzit/tortoise-pathway/issues/1