### PR TITLE
Handle connection close error if Tortoise initialization failed

### DIFF
--- a/tortoise_pathway/cli.py
+++ b/tortoise_pathway/cli.py
@@ -12,6 +12,7 @@ import functools
 from typing import Dict, Any, Callable, TypeVar, Coroutine
 
 from tortoise import Tortoise
+from tortoise.exceptions import ConfigurationError
 
 from tortoise_pathway.migration_manager import MigrationManager
 
@@ -29,7 +30,11 @@ def close_connections_after(
         try:
             return await func(*args, **kwargs)
         finally:
-            await Tortoise.close_connections()
+            try:
+                await Tortoise.close_connections()
+            except ConfigurationError:
+                # If Tortoise is not initialized, we can ignore this error
+                pass
 
     return wrapper
 


### PR DESCRIPTION
If running `make` with a missing `TORTOISE_ORM` config, this error is raised on exit (obviously, since the initialization failed):
```
tortoise.exceptions.ConfigurationError: DB configuration not initialised. Make sure to call Tortoise.init with a valid configuration before attempting to create connections.
```
This PR suppresses that error.