### PR TITLE
Make table argument required for CreateTable

### DIFF
--- a/tests/e2e/test_applied_migrations/migrations/test_applied_migrations/20240401000000_initial_donotdelete.py
+++ b/tests/e2e/test_applied_migrations/migrations/test_applied_migrations/20240401000000_initial_donotdelete.py
@@ -21,6 +21,7 @@ class InitialMigration(Migration):
     operations = [
         CreateModel(
             model="test_applied_migrations.Product",
+            table="products",
             fields={
                 "id": IntField(primary_key=True),
                 "name": CharField(max_length=255),
@@ -32,6 +33,7 @@ class InitialMigration(Migration):
         ),
         CreateModel(
             model="test_applied_migrations.Category",
+            table="categories",
             fields={
                 "id": IntField(primary_key=True),
                 "name": CharField(max_length=100),

--- a/tests/e2e/test_model_changes/migrations/test_model_changes/20240401000000_initial_donotdelete.py
+++ b/tests/e2e/test_model_changes/migrations/test_model_changes/20240401000000_initial_donotdelete.py
@@ -19,6 +19,7 @@ class InitialMigration(Migration):
     operations = [
         CreateModel(
             model="test_model_changes.Blog",
+            table="blogs",
             fields={
                 "id": IntField(primary_key=True),
                 "slug": CharField(max_length=255),
@@ -30,6 +31,7 @@ class InitialMigration(Migration):
         ),
         CreateModel(
             model="test_model_changes.Tag",
+            table="tags",
             fields={
                 "id": IntField(primary_key=True),
                 "name": CharField(max_length=50, unique=True),

--- a/tests/operations/test_add_column.py
+++ b/tests/operations/test_add_column.py
@@ -9,31 +9,26 @@ from tortoise_pathway.state import State
 
 async def test_add_column(setup_test_db):
     """Test AddField operation."""
-    state = State("test")
-
-    # First create a table
-    fields_dict = {
-        "id": fields.IntField(primary_key=True),
-        "name": fields.CharField(max_length=100),
-    }
+    state = State("tests")
 
     create_op = CreateModel(
-        model="tests.models.TestModel",
-        fields=fields_dict,
+        model="tests.TestModel",
+        table="test_add_column",
+        fields={
+            "id": fields.IntField(primary_key=True),
+            "name": fields.CharField(max_length=100),
+        },
     )
-    # Set table name manually for test
-    create_op.set_table_name("test_add_column")
     await create_op.apply(state=state)
+    state.apply_operation(create_op)
 
     # Add a column
     field = fields.IntField(default=0)
     operation = AddField(
-        model="tests.models.TestModel",
+        model="tests.TestModel",
         field_object=field,
         field_name="int_field",
     )
-    # Set table name manually for test
-    operation.set_table_name("test_add_column")
     await operation.apply(state=state)
 
     # Verify column was added

--- a/tests/operations/test_add_index.py
+++ b/tests/operations/test_add_index.py
@@ -9,7 +9,7 @@ from tortoise_pathway.state import State
 
 async def test_add_index(setup_test_db):
     """Test AddIndex operation."""
-    state = State("test")
+    state = State("tests")
 
     # First create a table
     fields_dict = {
@@ -18,20 +18,18 @@ async def test_add_index(setup_test_db):
     }
 
     create_op = CreateModel(
-        model="tests.models.TestModel",
+        model="tests.TestModel",
+        table="test_add_index",
         fields=fields_dict,
     )
-    # Set table name manually for test
-    create_op.set_table_name("test_add_index")
     await create_op.apply(state=state)
+    state.apply_operation(create_op)
 
     # Add an index
     operation = AddIndex(
-        model="tests.models.TestModel",
+        model="tests.TestModel",
         field_name="name",
     )
-    # Set table name manually for test
-    operation.set_table_name("test_add_index")
     await operation.apply(state=state)
 
     # Verify index was added (for SQLite)

--- a/tests/operations/test_create_table.py
+++ b/tests/operations/test_create_table.py
@@ -21,10 +21,9 @@ async def test_create_table(setup_test_db):
     # Create and apply operation
     operation = CreateModel(
         model="tests.models.TestModel",
+        table="test_create",
         fields=fields_dict,
     )
-    # Set table name manually to override automatic name derivation
-    operation.set_table_name("test_create")
     await operation.apply(state=state)
 
     # Verify table was created
@@ -56,9 +55,9 @@ class TestSqliteDialect:
 
         operation = CreateModel(
             model="tests.models.TestModel",
+            table="test_table",
             fields=fields_dict,
         )
-        operation.set_table_name("test_table")
 
         # Test SQLite dialect
         sql = operation.forward_sql(state=state, dialect="sqlite")
@@ -89,9 +88,9 @@ class TestSqliteDialect:
 
         operation = CreateModel(
             model="tests.models.TestModel",
+            table="test_constraints",
             fields=fields_dict,
         )
-        operation.set_table_name("test_constraints")
 
         sql = operation.forward_sql(state=state)
 
@@ -119,9 +118,9 @@ class TestSqliteDialect:
 
         operation = CreateModel(
             model="tests.models.Post",
+            table="posts",
             fields=fields_dict,
         )
-        operation.set_table_name("posts")
 
         sql = operation.forward_sql(state=state)
 
@@ -149,9 +148,9 @@ class TestPostgresDialect:
 
         operation = CreateModel(
             model="tests.models.TestModel",
+            table="test_postgres",
             fields=fields_dict,
         )
-        operation.set_table_name("test_postgres")
 
         sql = operation.forward_sql(state=state, dialect="postgres")
 

--- a/tests/operations/test_drop_index.py
+++ b/tests/operations/test_drop_index.py
@@ -9,7 +9,7 @@ from tortoise_pathway.state import State
 
 async def test_drop_index(setup_test_db):
     """Test DropIndex operation."""
-    state = State("test")
+    state = State("tests")
 
     # First create a table
     fields_dict = {
@@ -18,20 +18,18 @@ async def test_drop_index(setup_test_db):
     }
 
     create_op = CreateModel(
-        model="tests.models.TestModel",
+        model="tests.TestModel",
+        table="test_drop_index",
         fields=fields_dict,
     )
-    # Set table name manually for test
-    create_op.set_table_name("test_drop_index")
     await create_op.apply(state=state)
+    state.apply_operation(create_op)
 
     # Add an index
     add_index_op = AddIndex(
-        model="tests.models.TestModel",
+        model="tests.TestModel",
         field_name="name",
     )
-    # Set table name manually for test
-    add_index_op.set_table_name("test_drop_index")
     await add_index_op.apply(state=state)
 
     # Verify index exists
@@ -48,8 +46,6 @@ async def test_drop_index(setup_test_db):
         model="tests.models.TestModel",
         field_name="name",
     )
-    # Set table name manually for test
-    operation.set_table_name("test_drop_index")
     await operation.apply(state=state)
 
     # Verify index was dropped

--- a/tests/operations/test_drop_table.py
+++ b/tests/operations/test_drop_table.py
@@ -7,7 +7,7 @@ from tortoise_pathway.state import State
 
 async def test_drop_table(setup_test_db):
     """Test DropModel operation."""
-    state = State("test")
+    state = State("tests")
 
     # First create a table
     fields_dict = {
@@ -16,21 +16,19 @@ async def test_drop_table(setup_test_db):
     }
 
     create_op = CreateModel(
-        model="tests.models.TestModel",
+        model="tests.TestModel",
+        table="test_drop",
         fields=fields_dict,
     )
-    # Set table name manually for test
-    create_op.set_table_name("test_drop")
     await create_op.apply(state=state)
+    state.apply_operation(create_op)
 
     # Verify table exists
     conn = Tortoise.get_connection("default")
     await conn.execute_query("SELECT * FROM test_drop")
 
     # Drop the table
-    operation = DropModel(model="tests.models.TestModel")
-    # Set table name manually for test
-    operation.set_table_name("test_drop")
+    operation = DropModel(model="tests.TestModel")
     await operation.apply(state=state)
 
     # Verify table was dropped

--- a/tests/test_schema_diff_fields.py
+++ b/tests/test_schema_diff_fields.py
@@ -36,6 +36,7 @@ async def test_detect_field_additions():
 
     create_model_op = CreateModel(
         model="test.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -95,6 +96,7 @@ async def test_detect_field_removals():
 
     create_model_op = CreateModel(
         model="test.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -154,6 +156,7 @@ async def test_detect_field_alterations():
 
     create_model_op = CreateModel(
         model="test.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -231,6 +234,7 @@ async def test_detect_field_type_changes():
 
     create_model_op = CreateModel(
         model="test.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -294,6 +298,7 @@ async def test_detect_multiple_field_changes():
 
     create_model_op = CreateModel(
         model="test.TestModel",
+        table="test_model",
         fields=fields,
     )
 

--- a/tests/test_schema_diff_indexes.py
+++ b/tests/test_schema_diff_indexes.py
@@ -22,6 +22,7 @@ async def test_detect_index_additions():
 
     create_model_op = CreateModel(
         model="test.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -74,6 +75,7 @@ async def test_detect_index_removals():
     state.apply_operation(
         CreateModel(
             model="test.TestModel",
+            table="test_model",
             fields=fields,
         )
     )
@@ -119,6 +121,7 @@ async def test_detect_index_modifications():
     state.apply_operation(
         CreateModel(
             model="test.TestModel",
+            table="test_model",
             fields=fields,
         )
     )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,6 +3,7 @@ Tests for the State class.
 """
 
 
+import pytest
 from tortoise.fields import IntField, CharField, TextField, DatetimeField
 
 from tortoise_pathway.state import State
@@ -36,6 +37,7 @@ async def test_apply_create_model():
     # Create a migration operation
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -69,6 +71,7 @@ async def test_apply_add_field():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -118,6 +121,7 @@ async def test_apply_drop_field():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -164,6 +168,7 @@ async def test_apply_alter_field():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -213,6 +218,7 @@ async def test_apply_rename_field():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -260,6 +266,7 @@ async def test_apply_rename_model():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -300,6 +307,7 @@ async def test_get_schema():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -332,6 +340,7 @@ async def test_get_model():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -357,6 +366,7 @@ async def test_get_table_name():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -389,6 +399,7 @@ async def test_get_column_name():
 
     create_model_op = CreateModel(
         model="test_app.TestModel",
+        table="test_model",
         fields=fields,
     )
 
@@ -405,23 +416,18 @@ async def test_get_column_name():
     assert custom_column == "custom_column"  # Custom column name from source_field
 
 
-async def test_ignore_operations_for_different_app():
-    """Test that operations for different app are ignored."""
+async def test_app_validation():
     state = State("test_app")
-
-    # Create a model for a different app
-    fields = {
-        "id": IntField(primary_key=True),
-        "name": CharField(max_length=100),
-    }
 
     create_model_op = CreateModel(
         model="other_app.TestModel",
-        fields=fields,
+        table="test_model",
+        fields={
+            "id": IntField(primary_key=True),
+            "name": CharField(max_length=100),
+        },
     )
 
     # Apply the operation to the state
-    state.apply_operation(create_model_op)
-
-    # State should be empty as the operation was for a different app
-    assert state.get_schema() == {"models": {}}
+    with pytest.raises(ValueError):
+        state.apply_operation(create_model_op)

--- a/tortoise_pathway/operations/alter_field.py
+++ b/tortoise_pathway/operations/alter_field.py
@@ -113,8 +113,7 @@ class AlterField(Operation):
         # Create temporary model with the updated fields
         from tortoise_pathway.operations.create_model import CreateModel
 
-        temp_model = CreateModel(self.model, model_fields)
-        temp_model.set_table_name(temp_table_name)
+        temp_model = CreateModel(self.model, temp_table_name, model_fields)
 
         # Generate CREATE TABLE statement for the new table
         sql += temp_model.forward_sql(state, "sqlite") + ";\n"

--- a/tortoise_pathway/operations/create_model.py
+++ b/tortoise_pathway/operations/create_model.py
@@ -21,9 +21,11 @@ class CreateModel(Operation):
     def __init__(
         self,
         model: str,
+        table: str,
         fields: Dict[str, Field],
     ):
         super().__init__(model)
+        self.table = table
         self.fields = fields
 
     def forward_sql(self, state: "State", dialect: str = "sqlite") -> str:
@@ -32,7 +34,7 @@ class CreateModel(Operation):
 
     def backward_sql(self, state: "State", dialect: str = "sqlite") -> str:
         """Generate SQL for dropping the table."""
-        return f"DROP TABLE {self.get_table_name(state)}"
+        return f"DROP TABLE {self.table}"
 
     def _generate_sql_from_fields(self, state: "State", dialect: str = "sqlite") -> str:
         """
@@ -73,7 +75,7 @@ class CreateModel(Operation):
             columns.append(f"{db_column} {column_def}")
 
         # Build the CREATE TABLE statement
-        sql = f'CREATE TABLE "{self.get_table_name(state)}" (\n'
+        sql = f'CREATE TABLE "{self.table}" (\n'
         sql += ",\n".join(["    " + col for col in columns])
 
         if constraints:
@@ -88,6 +90,7 @@ class CreateModel(Operation):
         lines = []
         lines.append("CreateModel(")
         lines.append(f'    model="{self.model}",')
+        lines.append(f'    table="{self.table}",')
 
         # Include fields
         lines.append("    fields={")

--- a/tortoise_pathway/operations/operation.py
+++ b/tortoise_pathway/operations/operation.py
@@ -37,7 +37,6 @@ class Operation:
     ):
         self.model = model
         self.app_name, self.model_name = self._split_model_reference(model)
-        self._override_table_name = None
 
     def _split_model_reference(self, model_ref: str) -> tuple:
         """Split model reference into app and model name."""
@@ -56,11 +55,7 @@ class Operation:
         Returns:
             The table name for the model.
         """
-        # First check if there's an override
-        if self._override_table_name:
-            return self._override_table_name
-
-            # Use the state's get_table_name method
+        # Use the state's get_table_name method
         table_name = state.get_table_name(self.model_name)
         if table_name:
             return table_name
@@ -85,15 +80,6 @@ class Operation:
 
         s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", self.model_name)
         return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
-
-    def set_table_name(self, table_name: str) -> None:
-        """
-        Override the table name for testing or specific use cases.
-
-        Args:
-            table_name: The table name to use.
-        """
-        self._override_table_name = table_name
 
     async def apply(self, state: "State", connection_name: str = "default") -> None:
         """

--- a/tortoise_pathway/schema_differ.py
+++ b/tortoise_pathway/schema_differ.py
@@ -211,6 +211,7 @@ class SchemaDiffer:
             self._changes.append(
                 CreateModel(
                     model=model_ref,
+                    table=model_info["table"],
                     fields=field_objects,
                 )
             )


### PR DESCRIPTION
We need to know the table name at the moment when the operation is applied, we cannot rely on the current table name in the model since there could be a later operation renaming the table.