### PR TITLE
Add db_index support to fields

### DIFF
--- a/tests/operations/test_add_field.py
+++ b/tests/operations/test_add_field.py
@@ -38,6 +38,21 @@ class TestSqliteDialect:
 
         assert sql == "ALTER TABLE test_table ADD COLUMN count INT NOT NULL DEFAULT 0"
 
+    def test_add_field_with_index(self):
+        """Test SQL generation for adding a regular field."""
+        state = State("test", schema={"models": {"TestModel": {"table": "test_table"}}})
+
+        # Test adding a text field
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.CharField(max_length=100, null=True, db_index=True),
+            field_name="description",
+        )
+
+        sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
+
+        assert sql == "ALTER TABLE test_table ADD COLUMN description VARCHAR(100);\nCREATE INDEX idx_test_table_description ON test_table (description)"
+
     def test_add_foreign_key(self):
         """Test SQL generation for adding a foreign key field with SQLite."""
         state = State(
@@ -78,6 +93,21 @@ class TestPostgresDialect:
         sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
 
         assert sql == "ALTER TABLE test_table ADD COLUMN description TEXT"
+
+    def test_add_field_with_index(self):
+        """Test SQL generation for adding a regular field."""
+        state = State("test", schema={"models": {"TestModel": {"table": "test_table"}}})
+
+        # Test adding an indexed char field
+        operation = AddField(
+            model="tests.models.TestModel",
+            field_object=fields.CharField(max_length=100, null=True, db_index=True),
+            field_name="description",
+        )
+
+        sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
+
+        assert sql == "ALTER TABLE test_table ADD COLUMN description VARCHAR(100);\nCREATE INDEX idx_test_table_description ON test_table (description)"
 
     def test_add_foreign_key(self):
         """Test SQL generation for adding a foreign key field with PostgreSQL."""

--- a/tests/operations/test_alter_field.py
+++ b/tests/operations/test_alter_field.py
@@ -224,6 +224,56 @@ class TestPostgresDialect:
 ALTER TABLE test_table ADD CONSTRAINT count_key UNIQUE (count);"""
         )
 
+    def test_add_index(self):
+        """Test SQL generation for making a field indexed in PostgreSQL."""
+        # Create state with non-unique field
+        state = State(
+            "tests",
+            {
+                "models": {
+                    "TestModel": {
+                        "table": "test_table",
+                        "fields": {"email": fields.CharField(max_length=255, db_index=False)},
+                    }
+                }
+            },
+        )
+
+        # Make the field unique
+        operation = AlterField(
+            model="tests.TestModel",
+            field_object=fields.CharField(max_length=255, db_index=True),
+            field_name="email",
+        )
+
+        sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
+        assert sql == "CREATE INDEX idx_test_table_email ON test_table (email)"
+
+    def test_remove_index(self):
+        """Test SQL generation for removing an index in PostgreSQL."""
+        # Create state with an indexed field
+        state = State(
+            "tests",
+            {
+                "models": {
+                    "TestModel": {
+                        "table": "test_table",
+                        "fields": {"email": fields.CharField(max_length=255, db_index=True)},
+                    }
+                }
+            },
+        )
+
+        # Remove the index
+        operation = AlterField(
+            model="tests.TestModel",
+            field_object=fields.CharField(max_length=255),
+            field_name="email",
+        )
+
+        sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
+        assert sql == "DROP INDEX idx_test_table_email"
+
     def test_to_migration(self):
         """Test generating migration code for AlterField."""
         operation = AlterField(

--- a/tests/operations/test_alter_field.py
+++ b/tests/operations/test_alter_field.py
@@ -274,6 +274,31 @@ ALTER TABLE test_table ADD CONSTRAINT count_key UNIQUE (count);"""
         sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
         assert sql == "DROP INDEX idx_test_table_email"
 
+    def test_add_index_long_name(self):
+        """Test SQL generation for making a field indexed in PostgreSQL."""
+        # Create state with non-unique field
+        state = State(
+            "tests",
+            {
+                "models": {
+                    "TestModel": {
+                        "table": "test_table_for_long_index_name",
+                        "fields": {"email_address_for_long_index_name": fields.CharField(max_length=255, db_index=False)},
+                    }
+                }
+            },
+        )
+
+        # Make the field unique
+        operation = AlterField(
+            model="tests.TestModel",
+            field_object=fields.CharField(max_length=255, db_index=True),
+            field_name="email_address_for_long_index_name",
+        )
+
+        sql = operation.forward_sql(state=state, schema_manager=PostgresSchemaManager())
+        assert sql == "CREATE INDEX idx_test_table__email_a_596fb3 ON test_table_for_long_index_name (email_address_for_long_index_name)"
+
     def test_to_migration(self):
         """Test generating migration code for AlterField."""
         operation = AlterField(

--- a/tortoise_pathway/field_ext.py
+++ b/tortoise_pathway/field_ext.py
@@ -52,6 +52,9 @@ def field_to_migration(field: Field) -> str:
     if hasattr(field, "unique") and field.unique:
         params.append("unique=True")
 
+    if hasattr(field, "index") and field.index:
+        params.append("db_index=True")
+
     if hasattr(field, "enum_type"):
         enum_type = getattr(field, "enum_type")
         params.append(f"enum_type={enum_type.__name__}")

--- a/tortoise_pathway/field_ext.py
+++ b/tortoise_pathway/field_ext.py
@@ -49,10 +49,10 @@ def field_to_migration(field: Field) -> str:
     if hasattr(field, "null") and field.null:
         params.append("null=True")
 
-    if hasattr(field, "unique") and field.unique:
+    if hasattr(field, "unique") and field.unique and not field.pk:
         params.append("unique=True")
 
-    if hasattr(field, "index") and field.index:
+    if hasattr(field, "index") and field.index and not field.pk:
         params.append("db_index=True")
 
     if hasattr(field, "enum_type"):

--- a/tortoise_pathway/schema/base.py
+++ b/tortoise_pathway/schema/base.py
@@ -50,7 +50,7 @@ class BaseSchemaManager:
         sql += "\n);"
 
         if indexes:
-            sql += ";\n" + ";\n".join(indexes)
+            sql += "\n" + ";\n".join(indexes)
 
         return sql
 

--- a/tortoise_pathway/schema/base.py
+++ b/tortoise_pathway/schema/base.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 from typing import Any
 from tortoise.fields import Field, IntField
 from tortoise.fields.relational import RelationalField
@@ -29,8 +30,10 @@ class BaseSchemaManager:
         for column_name, field in columns.items():
             column_def = self._field_definition_to_sql(field)
             column_defs.append(f"{column_name} {column_def}")
-            if field.index:
-                index_name = self._column_index_name(table_name, column_name)
+
+            # Add indexes to non-primary key fields
+            if field.index and not field.pk:
+                index_name = self._get_index_name(table_name, column_name)
                 indexes.append(self.add_index(table_name, index_name, [column_name], unique=field.unique))
 
         for from_column, related_table, to_column in foreign_keys:
@@ -60,8 +63,8 @@ class BaseSchemaManager:
     def add_column(self, table_name: str, column_name: str, field: Field) -> str:
         column_def = self._field_definition_to_sql(field)
         statement = f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_def}"
-        if field.index:
-            index_name = self._column_index_name(table_name, column_name)
+        if field.index and not field.pk:
+            index_name = self._get_index_name(table_name, column_name)
             statement += ";\n" + self.add_index(table_name, index_name, [column_name], unique=field.unique)
         return statement
 
@@ -123,8 +126,8 @@ class BaseSchemaManager:
                 statements.append(f"ALTER TABLE {table_name} DROP CONSTRAINT {column_name}_key;")
 
         # Index change
-        if index != prev_field.index:
-            index_name = self._column_index_name(table_name, column_name)
+        if index != prev_field.index and not is_pk:
+            index_name = self._get_index_name(table_name, column_name)
             if index:
                 statements.append(self.add_index(table_name, index_name, [column_name], unique=unique))
             else:
@@ -200,8 +203,19 @@ class BaseSchemaManager:
 
         return column_def
     
-    def _column_index_name(self, table_name: str, column_name: str) -> str:
-        return f"idx_{table_name}_{column_name}"
+    def _get_index_name(self, table_name: str, column_name: str, prefix: str = "idx") -> str:
+        """
+        Generates a unique index name for a column.  Implementation is based on tortoise's schema generator.
+
+        NOTE: for compatibility, index name should not be longer than 30 characters (Oracle limit).
+        """
+        
+        full_index_name = f"{prefix}_{table_name}_{column_name}"
+        if len(full_index_name) <= 30:
+            return full_index_name
+        else:
+            hashed = self._make_hash(table_name, column_name, length=6)
+            return f"{prefix}_{table_name[:11]}_{column_name[:7]}_{hashed}"
 
     def field_default_to_sql(self, field: Field) -> str:
         default = getattr(field, "default", None)
@@ -231,3 +245,8 @@ class BaseSchemaManager:
 
     def _default_pk_keyword(self, pk_field: Field):
         return "PRIMARY KEY"
+
+    @staticmethod
+    def _make_hash(*args: str, length: int) -> str:
+        # Hash a set of string values and get a digest of the given length.
+        return sha256(";".join(args).encode("utf-8")).hexdigest()[:length]


### PR DESCRIPTION
Adds support for setting `db_index` to fields.  I decided to pack it into the `AlterField` change since it is similar to `unique`, but applied in a different way.  An alternate implementation could be adding this in as a `AddIndex`/`DropIndex` operation, but considering this derives from the field definition, I think using `AlterField` makes more sense from a migration readability standpoint.

Prior to this change, using `db_index` makes migrations generate every time with no field changes.