### PR TITLE
Migration Create/Apply Generators

### DIFF
--- a/tests/e2e/test_applied_migrations/test_applied_migrations_app.py
+++ b/tests/e2e/test_applied_migrations/test_applied_migrations_app.py
@@ -29,7 +29,9 @@ async def test_applied_migrations(setup_test_db):
     assert len(manager.get_pending_migrations()) == 1
 
     # Apply the migration
-    applied = await manager.apply_migrations()
+    applied = []
+    async for migration in manager.apply_migrations():
+        applied.append(migration)
     assert len(applied) == 1
 
     # Verify migration was applied

--- a/tests/e2e/test_model_changes/test_model_changes_app.py
+++ b/tests/e2e/test_model_changes/test_model_changes_app.py
@@ -39,7 +39,9 @@ async def test_model_changes(setup_test_db):
     assert len(manager.get_pending_migrations()) == 1
 
     # Apply the initial migration
-    applied = await manager.apply_migrations()
+    applied = []
+    async for migration in manager.apply_migrations():
+        applied.append(migration)
     assert len(applied) == 1
 
     # Check the database to verify initial tables were created
@@ -50,9 +52,11 @@ async def test_model_changes(setup_test_db):
         await conn.execute_query("SELECT * FROM comments")
 
     # Detect changes and create a new migration
-    migrations = await manager.create_migrations("model_changes", auto=True)
-    assert len(migrations) == 1
-    migration = migrations[0]
+    created = []
+    async for migration in manager.create_migrations("model_changes", auto=True):
+        created.append(migration)
+    assert len(created) == 1
+    migration = created[0]
     assert migration.path().exists()
 
     # Verify operations in the migration
@@ -146,7 +150,9 @@ async def test_model_changes(setup_test_db):
         assert "content" in content
 
     # Apply the new migration
-    applied = await manager.apply_migrations()
+    applied = []
+    async for migration in manager.apply_migrations():
+        applied.append(migration)
     assert len(applied) == 1
 
     # Verify all migrations are now applied

--- a/tests/e2e/test_no_migrations/test_no_migrations_app.py
+++ b/tests/e2e/test_no_migrations/test_no_migrations_app.py
@@ -32,9 +32,11 @@ async def test_create_initial_migration(setup_test_db):
     assert len(manager.get_pending_migrations()) == 0
 
     # Create an initial migration
-    migrations = await manager.create_migrations("initial", auto=True)
-    assert len(migrations) == 1
-    migration = migrations[0]
+    created = []
+    async for migration in manager.create_migrations("initial", auto=True):
+        created.append(migration)
+    assert len(created) == 1
+    migration = created[0]
     assert migration.path().exists()
 
     # Re-discover migrations and verify the new migration is found
@@ -74,11 +76,16 @@ async def test_create_initial_migration(setup_test_db):
     assert operations[3].index.name == "uniq_notes_user_ti_70d5aa"
     assert operations[3].index.fields == ["user", "title"]
 
-    applied = await manager.apply_migrations()
+    applied = []
+    async for migration in manager.apply_migrations():
+        applied.append(migration)
     assert len(applied) == 1
 
     # Verify all migrations are now applied
     assert len(manager.get_applied_migrations()) == 1
     assert len(manager.get_pending_migrations()) == 0
 
-    assert await manager.create_migrations("no_changes", auto=True) == []
+    created = []
+    async for migration in manager.create_migrations("no_changes", auto=True):
+        created.append(migration)
+    assert len(created) == 0

--- a/tortoise_pathway/cli.py
+++ b/tortoise_pathway/cli.py
@@ -241,7 +241,9 @@ def main() -> None:
     make_parser = subparsers.add_parser("make", help="Create new migration(s)")
     make_parser.add_argument("--app", help="App name")
     make_parser.add_argument("--name", help="Migration name (default: 'auto')")
-    make_parser.add_argument("--empty", action="store_true", help="Create an empty migration")
+    make_parser.add_argument(
+        "--empty", action="store_true", help="Create an empty migration"
+    )
     make_parser.add_argument(
         "--directory", help="Base migrations directory (default: 'migrations')"
     )
@@ -262,7 +264,9 @@ def main() -> None:
     )
 
     # showmigrations command
-    show_parser = subparsers.add_parser("showmigrations", help="List migrations and their status")
+    show_parser = subparsers.add_parser(
+        "showmigrations", help="List migrations and their status"
+    )
     show_parser.add_argument("--app", help="App name")
     show_parser.add_argument(
         "--directory", help="Base migrations directory (default: 'migrations')"

--- a/tortoise_pathway/cli.py
+++ b/tortoise_pathway/cli.py
@@ -153,7 +153,9 @@ async def migrate(args: argparse.Namespace) -> None:
             migrations.append(migration)
 
         if migrations:
-            print(f"Successfully applied {len(migrations)} migration(s).")
+            print(
+                f"Successfully applied {len(migrations)} migration{'s' if len(migrations) > 1 else ''}."
+            )
         else:
             print("No migrations were applied.")
     except Exception as e:

--- a/tortoise_pathway/cli.py
+++ b/tortoise_pathway/cli.py
@@ -160,7 +160,6 @@ async def migrate(args: argparse.Namespace) -> None:
             print("No migrations were applied.")
     except Exception as e:
         print(f"Error applying migrations: {e}")
-        sys.exit(1)
 
 
 @close_connections_after
@@ -175,15 +174,18 @@ async def rollback(args: argparse.Namespace) -> None:
     manager = MigrationManager(apps, migration_dir)
     await manager.initialize()
 
-    if args.migration:
-        reverted = await manager.revert_migration(args.migration, app=app)
-    else:
-        reverted = await manager.revert_migration(app=app)
+    try:
+        if args.migration:
+            reverted = await manager.revert_migration(args.migration, app=app)
+        else:
+            reverted = await manager.revert_migration(app=app)
 
-    if reverted:
-        print(f"Successfully reverted migration: {reverted.display_name()}")
-    else:
-        print("No migration was reverted.")
+        if reverted:
+            print(f"Successfully reverted migration: {reverted.display_name()}")
+        else:
+            print("No migration was reverted.")
+    except Exception as e:
+        print(f"Error reverting migration: {e}")
 
 
 @close_connections_after

--- a/tortoise_pathway/migration_manager.py
+++ b/tortoise_pathway/migration_manager.py
@@ -291,11 +291,9 @@ class MigrationManager:
             # Rebuild state from remaining applied migrations
             self.applied_state = self.applied_state.prev()
 
-            print(f"Reverted migration: {migration_name}")
             return migration
 
         except Exception as e:
-            print(f"Error reverting migration {migration_name}: {e}")
             # Rollback transaction if supported
             raise
 

--- a/tortoise_pathway/migration_manager.py
+++ b/tortoise_pathway/migration_manager.py
@@ -91,7 +91,7 @@ class MigrationManager:
         self, name: str = None, app: str = None, auto: bool = True
     ) -> AsyncGenerator[Type[Migration], None]:
         """
-        Create new migration files and return the Migration instances.  If app is specified, the migration will be created for that app only (and all its dependencies).
+        Create new migration files and yield the Migration instances.  If app is specified, the migration will be created for that app only (and all its dependencies).
 
         Args:
             name: The descriptive name for the migration. If None, a name will be generated based on detected changes.
@@ -99,11 +99,12 @@ class MigrationManager:
             auto: Whether to auto-generate migration operations based on model changes
 
         Returns:
-            A Migration instance representing the newly created migration.
-            None if no changes were detected.
+            An async generator of Migration instances representing the newly created migrations.
+            Empty if no changes were detected.
 
         Raises:
             ImportError: If the migration file couldn't be loaded or no Migration class was found
+            ValueError: If no app is specified for an empty migration
         """
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
@@ -190,7 +191,7 @@ class MigrationManager:
         Apply pending migrations.
 
         Returns:
-            List of Migration instances that were applied
+            An async generator of Migration instances that were applied
         """
         conn = connection or Tortoise.get_connection("default")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -175,7 +176,7 @@ wheels = [
 
 [[package]]
 name = "tortoise-pathway"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "tortoise-orm" },
@@ -198,6 +199,7 @@ requires-dist = [
     { name = "psycopg", extras = ["pool"], marker = "extra == 'psycopg'", specifier = ">=3.2.6" },
     { name = "tortoise-orm", specifier = ">=0.24.2" },
 ]
+provides-extras = ["psycopg"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Finally, I can make smaller PRs 😂

This swaps migration manager to using generators and yielding migrations for create/apply.  This allows people to customize the output and show results as they occur when implementing the manager in their own tooling.  I also moved the responsibility of printing status to the CLI for these functions.