### PR TITLE
Add dry-run mode to make command

### DIFF
--- a/tortoise_pathway/cli.py
+++ b/tortoise_pathway/cli.py
@@ -143,6 +143,11 @@ async def migrate(args: argparse.Namespace) -> None:
         print("No pending migrations.")
         return
 
+    if args.dry_run:
+        print(f"SQL for {len(pending)} pending migration(s):")
+        print(manager.get_pending_migrations_sql(app=app))
+        return
+
     print(f"Applying {len(pending)} migration(s):")
     for migration in pending:
         print(f"  - {migration.display_name()}")
@@ -248,6 +253,7 @@ def main() -> None:
     migrate_parser.add_argument(
         "--directory", help="Base migrations directory (default: 'migrations')"
     )
+    migrate_parser.add_argument("--dry-run", action="store_true", help="Show SQL without applying")
 
     # rollback command
     rollback_parser = subparsers.add_parser("rollback", help="Revert migrations")

--- a/tortoise_pathway/operations/operation.py
+++ b/tortoise_pathway/operations/operation.py
@@ -14,19 +14,6 @@ if TYPE_CHECKING:
     from tortoise_pathway.state import State
 
 
-def get_dialect(connection) -> str:
-    """
-    Determine the database dialect from a connection.
-
-    Args:
-        connection: The database connection.
-
-    Returns:
-        A string representing the dialect ('sqlite', 'postgres', etc.)
-    """
-    return connection.capabilities.dialect
-
-
 class Operation:
     """Base class for all schema change operations.
 
@@ -121,7 +108,7 @@ class Operation:
             connection_name: The database connection name to use.
         """
         connection = connections.get(connection_name)
-        schema_manager = get_schema_manager(get_dialect(connection))
+        schema_manager = get_schema_manager(connection)
         sql = self.forward_sql(state=state, schema_manager=schema_manager)
         await connection.execute_script(sql)
 
@@ -134,7 +121,7 @@ class Operation:
             connection_name: The database connection name to use.
         """
         connection = connections.get(connection_name)
-        schema_manager = get_schema_manager(get_dialect(connection))
+        schema_manager = get_schema_manager(connection)
         sql = self.backward_sql(state=state, schema_manager=schema_manager)
         await connection.execute_script(sql)
 

--- a/tortoise_pathway/schema/__init__.py
+++ b/tortoise_pathway/schema/__init__.py
@@ -1,8 +1,11 @@
 import importlib
 
+from tortoise import BaseDBAsyncClient
+
 from tortoise_pathway.schema.base import BaseSchemaManager
 
 
-def get_schema_manager(dialect: str) -> BaseSchemaManager:
+def get_schema_manager(connection: BaseDBAsyncClient) -> BaseSchemaManager:
+    dialect = connection.capabilities.dialect
     module = importlib.import_module(f"tortoise_pathway.schema.{dialect}")
     return module.schema_manager

--- a/tortoise_pathway/state.py
+++ b/tortoise_pathway/state.py
@@ -96,7 +96,7 @@ class State:
         Args:
             name: The name of the snapshot.
         """
-        self._snapshots.append((name, copy.deepcopy(self)))
+        self._snapshots.append((name, self.copy()))
 
     def prev(self) -> "State":
         """
@@ -106,6 +106,12 @@ class State:
             return State()
         _, state = self._snapshots[-2]
         return state
+
+    def copy(self) -> "State":
+        """
+        Copy the state.
+        """
+        return copy.deepcopy(self)
 
     def _get_app_models(
         self, app_name: str, create: bool = False

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "tortoise-pathway"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "tortoise-orm" },


### PR DESCRIPTION
Add `--dry-run` argument to the `make` CLI command.

```bash
uv run python -m tortoise_pathway --config yourpackage.TORTOISE_ORM migrate --dry-run
Wargning! This project is in VERY early development and not yet ready for production use. Most things are broken and they will break again, APIs will change.
SQL for 1 pending migration(s):
-- Migration: models -> 20250705123958_auto
CREATE TABLE "model" (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    ...
);
```